### PR TITLE
Fix: Correct DROP TABLE implementation and bugs

### DIFF
--- a/src/observer/storage/common/db.cpp
+++ b/src/observer/storage/common/db.cpp
@@ -237,14 +237,14 @@ RC Db::drop_table(const char *table_name)
     }
 
     // 让表自己销毁（删文件）
-    RC rc = table->destroy(data_dir_.c_str());
+    RC rc = table->destroy();
     if (rc != RC::SUCCESS) {
         LOG_WARN("Failed to destroy table %s", table_name);
         return rc;
     }
 
     // 从 table_map_ 中删除表
-    table_map_.erase(table_name);
+    opened_tables_.erase(table_name);
 
     // 释放内存
     delete table;

--- a/src/observer/storage/common/table.cpp
+++ b/src/observer/storage/common/table.cpp
@@ -926,17 +926,17 @@ RC Table::sync()
   return rc;
 }
 
-RC Table::destroy(const char *base_dir)
+RC Table::destroy()
 {
   // 1) 删除元数据文件 .meta
-  std::string meta_file = std::string(base_dir) + "/" + name() + ".meta";
+  std::string meta_file = this->base_dir_ + "/" + name() + ".meta";
   if (unlink(meta_file.c_str()) != 0) {
     LOG_ERROR("Failed to remove meta file=%s, errno=%d", meta_file.c_str(), errno);
     return RC::GENERIC_ERROR;
   }
 
   // 2) 删除数据文件 .tbl
-  std::string data_file = std::string(base_dir) + "/" + name() + ".tbl";
+  std::string data_file = this->base_dir_ + "/" + name() + ".tbl";
   if (unlink(data_file.c_str()) != 0) {
     LOG_ERROR("Failed to remove data file=%s, errno=%d", data_file.c_str(), errno);
     return RC::GENERIC_ERROR;
@@ -945,7 +945,7 @@ RC Table::destroy(const char *base_dir)
   // 3) 删除所有索引文件 .idx
   for (Index *idx : indexes_) {
     const char *idx_name = idx->index_meta().name();
-    std::string idx_file = std::string(base_dir) + "/" + name() + "." + idx_name + ".idx";
+    std::string idx_file = this->base_dir_ + "/" + name() + "." + idx_name + ".idx";
     if (unlink(idx_file.c_str()) != 0) {
       LOG_ERROR("Failed to remove index file=%s, errno=%d", idx_file.c_str(), errno);
       return RC::GENERIC_ERROR;

--- a/src/observer/storage/common/table.h
+++ b/src/observer/storage/common/table.h
@@ -67,7 +67,7 @@ public:
       void (*record_reader)(const char *data, void *context));
 
   RC create_index(Trx *trx, const char *index_name, const char *attribute_name);
-  RC destroy(const char* dir);
+  RC destroy();
   RC get_record_scanner(RecordFileScanner &scanner);
 
   RecordFileHandler *record_handler() const

--- a/src/observer/storage/default/default_storage_stage.cpp
+++ b/src/observer/storage/default/default_storage_stage.cpp
@@ -169,8 +169,8 @@ void DefaultStorageStage::handle_event(StageEvent *event)
       snprintf(response, sizeof(response), "%s", result.c_str());
     } break;
       case SCF_DROP_TABLE: {
-    const DropTable& drop_table = sql->sstr[sql->q_size-1].drop_table; // 拿到要drop 的表
-    rc = handler_->drop_table(current_db,drop_table.relation_name); // 调用drop table接口，drop table要在handler中实现
+    const DropTable& drop_table = sql->sstr.drop_table; // 拿到要drop 的表
+    rc = handler_->drop_table(dbname, drop_table.relation_name); // 调用drop table接口，drop table要在handler中实现
     snprintf(response,sizeof(response),"%s\n", rc == RC::SUCCESS ? "SUCCESS" : "FAILURE"); // 返回结果，带不带换行符都可以
   }
 break;


### PR DESCRIPTION
This commit addresses issues in the `DROP TABLE` functionality:

1.  **Fixed `DefaultStorageStage::handle_event`**:
    *   Corrected the access to the `DropTable` structure within the `Query` object.
    *   Ensured the correct database name is passed to `DefaultHandler::drop_table`.

2.  **Fixed `Db::drop_table`**:
    *   Modified the call to `table->destroy()` to not pass arguments, relying on the `Table` object to use its internal path.
    *   Corrected the map used to track open tables from `table_map_` to `opened_tables_`.

3.  **Fixed `Table::destroy`**:
    *   Modified the method to use its internal `base_dir_` member for constructing file paths for deletion, instead of taking a directory path as a parameter.
    *   Updated the method declaration in the header file accordingly.

These changes ensure that `DROP TABLE` correctly removes table data, metadata, and associated index files. Existing test cases for `DROP TABLE` are comprehensive and cover these fixes.